### PR TITLE
Allow users to specify their own dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ jobs:
 ```
 I have this triggering in [another repository](https://github.com/Zoobdude/caddy-builder-with-modules) to build my own container
 
+Note: You can specify a custom Dockerfile path using the `dockerfile` input parameter.

--- a/action.yaml
+++ b/action.yaml
@@ -28,6 +28,10 @@ inputs:
     description: "List of target platforms for build"
     required: true
 
+  dockerfile:
+    description: "Path to a custom Dockerfile"
+    required: false
+
 runs:
   using: "composite"
   steps: 
@@ -55,7 +59,7 @@ runs:
         push: true
         tags: ${{ inputs.tags }}
         context: .
-        file: ${{ github.action_path }}/Dockerfile
+        file: ${{ inputs.dockerfile || github.action_path + '/Dockerfile' }}
         build-args: |
           "MODULES=${{ inputs.modules }}"
         platforms: ${{ inputs.platforms }}


### PR DESCRIPTION
Update `action.yaml` to allow users to specify their own Dockerfile path incase the default is not suitable for some reason.
