### PR TITLE
Rename tag to image

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
             github.com/porech/caddy-maxmind-geolocation
           docker-username: "zoobdude"
           docker-password: ${{ secrets.DOCKERHUB_TOKEN }}
-          tags: "zoobdude/caddy"
+          image: "zoobdude/caddy"
           platforms: linux/amd64,linux/arm64,linux/arm/v7
 ```
 I have this triggering in [another repository](https://github.com/Zoobdude/caddy-builder-with-modules) to build my own container

--- a/action.yaml
+++ b/action.yaml
@@ -20,8 +20,8 @@ inputs:
     description: "Password or personal access token used to log against the Docker registry"
     required: true
 
-  tags:
-    description: "List of tags"
+  image:
+    description: "Image to push"
     required: true
   
   platforms:
@@ -57,7 +57,7 @@ runs:
       uses: docker/build-push-action@v6
       with:
         push: true
-        tags: ${{ inputs.tags }}
+        tags: ${{ inputs.image }}
         context: .
         file: ${{ inputs.dockerfile || github.action_path + '/Dockerfile' }}
         build-args: |


### PR DESCRIPTION
Rename the input parameter `tags` to `image` in the `action.yaml` and `README.md` files. Tags is the incorrect term and in the next release, proper version tags are going to be made, rather than only pushing to latest.
