### PR TITLE
Add version tag to build and push step

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -53,11 +53,17 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    - name: Get Caddy base version
+      id: get_base_version
+      run: |
+        base_version=$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version" }}' caddy:latest)
+        echo "base_version=${base_version#v}" >> $GITHUB_ENV
+
     - name: Build and push
       uses: docker/build-push-action@v6
       with:
         push: true
-        tags: ${{ inputs.image }}
+        tags: ${{ inputs.image }}:${{ env.base_version }}
         context: .
         file: ${{ inputs.dockerfile || github.action_path + '/Dockerfile' }}
         build-args: |


### PR DESCRIPTION
Rather than just pushing to the :latest tag, extract the base caddy version and use that as the tag

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Zoobdude/caddy-docker-builder/pull/3?shareId=88ee6c82-fdd6-47b2-819c-94333c9abb94).